### PR TITLE
Translate syntax_and_semantic up to as.md

### DIFF
--- a/_gitbook/syntax_and_semantics/alias.md
+++ b/_gitbook/syntax_and_semantics/alias.md
@@ -1,6 +1,6 @@
 # alias
 
-With `alias` you can give a type a different name:
+透過 `alias` （別名）你可以給一個型別不同的名子：
 
 ```crystal
 alias PInt32 = Pointer(Int32)
@@ -8,9 +8,9 @@ alias PInt32 = Pointer(Int32)
 ptr = PInt32.malloc(1) # :: Pointer(Int32)
 ```
 
-Every time you use an alias the compiler replaces it with the type it refers to.
+每當你使用一次別名時編譯器會將之取代為其所指稱的型別。
 
-Aliases are useful to avoid writing long type names, but also to be able to talk about recursive types:
+別名在避免寫過長的型別名稱時非常方便，同時也能描述遞迴型別。
 
 ```crystal
 alias RecArray = Array(Int32) | Array(RecArray)
@@ -21,7 +21,7 @@ ary.push ary
 ary #=> [[1, 2, 3], [...]]
 ```
 
-A real-world example of a recursive type is json:
+一個真實世界的遞迴型別範例是 json ：
 
 ```crystal
 module Json

--- a/_gitbook/syntax_and_semantics/and.md
+++ b/_gitbook/syntax_and_semantics/and.md
@@ -1,13 +1,13 @@
 # &&
 
-An `&&` (and) evaluates its left hand side. If it's *truthy*, it evaluates its right hand side and has that value. Otherwise it has the value of the left hand side. Its type is the union of the types of both sides.
+一個 `&&` （且） 會計算左值。如果值為 *可信的*，他會計算右值並獲得其值，否則會獲得左值。他的型別將會是兩邊的混合型別。
 
-You can think an `&&` as syntax sugar of an `if`:
+你可以將一個 `&&` 視為一個 `if` 的語法糖：
 
 ```crystal
 some_exp1 && some_exp2
 
-# The above is the same as:
+# 上面與此等價:
 tmp = some_exp1
 if tmp
   some_exp2

--- a/_gitbook/syntax_and_semantics/as.md
+++ b/_gitbook/syntax_and_semantics/as.md
@@ -1,6 +1,6 @@
 # as
 
-The `as` expression restricts the types of an expression. For example:
+`as` 這個表達式侷限了一個表達式的型別。例如：
 
 ```crystal
 if some_condition
@@ -12,58 +12,58 @@ end
 # a :: Int32 | String
 ```
 
-In the above code, `a` is a union of `Int32 | String`. If for some reason we are sure `a` is an `Int32` after the `if`, we can force the compiler to treat it like one:
+上述的程式碼中， `a` 是一個 `Int32 | String` 的結合。假設因為某些原因我們確定 `a` 在 `if` 後面是一個 `Int32` ，我們可以強至編譯器處理時將其視為一個：
 
 ```crystal
 a_as_int = a as Int32
-a_as_int.abs          # works, compiler knows that a_as_int is Int32
+a_as_int.abs          # 可行，編譯器知道 a_as_int 是 Int32
 ```
 
-The `as` expression performs a runtime check: if `a` wasn't an `Int32`, an [exception](exception_handling.html) is raised.
+`as` 這個表達是進行一次執行期檢查：如果 `a` 並不是一個 `Int32` ， 將會引發 [例外](exception_handling.html) 。
 
-The argument to the expression is a [type](type_grammar.html).
+這個表達式的參數式一個 [型別](type_grammar.html) 。
 
-If it is impossible for a type to be restricted by another type, a compile-time error is issued:
+如果將一個型別被令一個型別侷限是不可行的，將會被告知一個編譯時期錯誤：
 
 ```crystal
 1 as String # Error
 ```
 
-**Note: ** you can't use `as` to convert a type to an unrelated type: `as` is not like a `cast` in other languages. Methods on integers, floats and chars are provided for these convertions. Alternatively, use pointer casts as explained below.
+**提醒： ** 你不能使用 `as` 將一個型別轉換為一個部相關的型別： `as` 並不像其他語言裡的 `cast` 。整數、浮點數和字元上有提供這些轉換的方法。或是，如下方解釋的使用指標轉變。
 
-## Converting between pointer types
+## 指標型別之間的轉換
 
-The `as` expression also allows to cast between pointer types:
+`as` 這個表達式也允許指標協別之間的轉變：
 
 ```crystal
 ptr = Pointer(Int32).malloc(1)
 ptr as Int8*                    #:: Pointer(Int8)
 ```
 
-In this case, no runtime checks are done: pointers are unsafe and this type of casting is usually only needed in C bindings and low-level code.
+於上方的案例，並沒有執行期檢查：指標非常的不安全，而這類型的轉變通常只有於 C 綁定或是低階程式碼中才必要。
 
-## Converting between pointer types and other types
+## 指標型別與其他型別之間的轉換
 
-Conversion between pointer types and Reference types is also possible:
+指標型別與參照型別之間的轉換也是可能的：
 
 ```crystal
 array = [1, 2, 3]
 
-# object_id returns the address of an object in memory,
-# so we create a pointer with that address
+# object_id 回傳一個物件在記憶體中的位址，
+# 所以我們創造一個擁有該位址的指標
 ptr = Pointer(Void).new(array.object_id)
 
-# Now we cast that pointer to the same type, and
-# we should get the same value
+# 現在我們可以把指標轉變為相同型態，然後
+# 我們應當會得到相同的值
 array2 = ptr as Array(Int32)
 array2.same?(array) #=> true
 ```
 
-No runtime checks are performed in these cases because, again, pointers are involved. The need for this cast is even more rare than the previous one, but allows to implement some core types (like String) in Crystal itself, and it also allows passing a Reference type to C functions by casting it to a void pointer.
+再一次強調，這些案例中因為指標的涉入而沒有執行執行期檢查。這種轉變的需求甚至比比前一向更罕見，但允許實作 Crystal 裡的一些核心型別（例如字串） ，而且他也允許將期透過轉換為 void 指標後傳遞一個參照型別給 C 函式。
 
-## Usage for casting to a bigger type
+## 轉換為更大的型別的使用情況
 
-The `as` expression can be used to cast an expression to a "bigger" type. For example:
+`as` 這個表達式可以被用於轉換為 " 更大的 " 型別。例如：
 
 ```crystal
 a = 1
@@ -71,23 +71,23 @@ b = a as Int32 | Float64
 b #:: Int32 | Float64
 ```
 
-The above might not seem to be useful, but it is when, for example, mapping an array of elements:
+上面的範例看起來可能不是很有用，但卻在 -- 舉例 -- 對應一個陣列中的元素時非常有用：
 
 ```crystal
 ary = [1, 2, 3]
 
-# We want to create an array 1, 2, 3 of Int32 | Float64
+# 我們想要創建一個 Int32 | Float64 的陣列 1, 2, 3
 ary2 = ary.map { |x| x as Int32 | Float64 }
 
 ary2 #:: Array(Int32 | Float64)
 ary2 << 1.5 # OK
 ```
 
-The `Array#map` method uses the block's type as the generic type for the Array. Without the `as` expression, the inferred type would have been `Int32` and we wouldn't have been able to add a `Float64` into it.
+`Array#map` 這個方法使用了區塊的型別作為陣列的一般型別。沒有 `as` 表達式時，推定的型別將會是 `Int32` 而且我們無法增加一個 `Float64` 進去。
 
-## Usage for when the compiler can't infer the type of a block
+## 當編譯器無法推斷一個區塊的型別的使用情況
 
-Sometimes the compiler can't infer the type of a block. For example:
+有時編譯器並不能推斷區塊的型別，例如：
 
 ```crystal
 class Person
@@ -103,14 +103,14 @@ a = [] of Person
 x = a.map { |f| f.name } # Error: can't infer block return type
 ```
 
-The compiler needs the block's type for the generic type of the Array created by `Array#map`, but since `Person` was never instantiated, the compiler doesn't know the type of `@name`. In this cases you can help the compiler by using an `as` expression:
+編譯器需要區塊的型別以作為 `Array#map` 創建的陣列的一般型別，但既然 `Person` 從來沒有被實例化，編譯器並不知道 `@name` 的型別。在這個案例中你可以透過一個 `as` 表達式幫助編譯器：
 
 ```crystal
 a = [] of Person
 x = a.map { |f| f.name as String } # OK
 ```
 
-This error isn't very frequent, and is usually gone if a `Person` is instantiated before the map call:
+這個錯誤並不是很頻繁，而且通常在一個 `Person` 被 map 呼叫以前被實例化後消失：
 
 ```crystal
 Person.new "John"


### PR DESCRIPTION
Tried to translate some part, but I'm not sure how to translate `map` in as.md, so I just leave it as what it was.
